### PR TITLE
Replaced DropDownComboBox with MRUComboBox

### DIFF
--- a/Tvl.DebugCommandLine/DebugCommandLine.vsct
+++ b/Tvl.DebugCommandLine/DebugCommandLine.vsct
@@ -4,7 +4,7 @@
 
   <Commands package="guidDebugCommandLinePackage">
     <Combos>
-      <Combo guid="guidDebugCommandLineCommandSet" id="cmdidDebugCommandLineCombo" priority="0x0000" type="DropDownCombo" defaultWidth="135" idCommandList="cmdidDebugCommandLineComboGetList">
+      <Combo guid="guidDebugCommandLineCommandSet" id="cmdidDebugCommandLineCombo" priority="0x0000" type="MRUCombo" defaultWidth="135" idCommandList="cmdidDebugCommandLineComboGetList">
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>CommandWellOnly</CommandFlag>


### PR DESCRIPTION
To add to this issue https://github.com/tunnelvisionlabs/DebugCommandLine/issues/7, I made a fork https://github.com/CoderGimmic/DebugCommandLine/commit/b588ec9d32186f6f149e18c56c929d8c5c1a19ac and replaced the existing ComboBox with a MRUComboBox. It's the first time I'm writing code to extend Visual Studio so there's probably something I've missed. I'll gladly fix any things done wrong given some pointers as I'd really like this feature to be implemented, or feel free to use my commit as a basis to implement the feature yourself instead.

Currently I've just replaced the existing ComboBox with a MRUComboBox using the following example code as base https://github.com/Microsoft/VSSDK-Extensibility-Samples/blob/master/Combo_Box/C%23/VsPkg.cs#L320. So Instead of having multiple events tied to the regular dropdown I've replaced them with a single event which handles read and writes using your backend to get the command line arguments. 

According to the example provided above: "The list of choices entered is automatically remembered by the IDE on a per-user/per-machine basis." when using a MRU ComboBox. So as of now I've just disabled the SettingsStore which you've implemented.

This tool is invaluable to me as I'm often switching between command arguments, thanks!

~Gimmic